### PR TITLE
Upgrade to java gitlab api 1 2 7 and support for self-signed SSL certs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,6 @@
         <relativePath></relativePath>
     </parent>
 
-    <groupId>com.evolveum.polygon</groupId>
     <artifactId>connector-gitlab</artifactId>
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
@@ -76,7 +75,7 @@
 	    <dependency>
 	    	<groupId>org.gitlab</groupId>
 	    	<artifactId>java-gitlab-api</artifactId>
-	    	<version>1.1.6-SNAPSHOT</version>
+	    	<version>1.2.7</version>
 	    </dependency>
     </dependencies>
 </project>

--- a/src/main/java/com/evolveum/polygon/connector/gitlab/GitlabConfiguration.java
+++ b/src/main/java/com/evolveum/polygon/connector/gitlab/GitlabConfiguration.java
@@ -17,23 +17,21 @@
 package com.evolveum.polygon.connector.gitlab;
 
 import org.identityconnectors.framework.spi.AbstractConfiguration;
-import org.identityconnectors.common.logging.Log;
 import org.identityconnectors.framework.spi.ConfigurationProperty;
 
 public class GitlabConfiguration extends AbstractConfiguration {
 
-    private static final Log LOG = Log.getLog(GitlabConfiguration.class);
-
     private String hostUrl;
     private String apiToken;
+    private boolean ignoreCertificateErrors = false;
 
     @Override
     public void validate() {
         //todo implement
     }
 
-    @ConfigurationProperty(displayMessageKey = "${connectorNameLowerCase}.config.hostUrl",
-            helpMessageKey = "${connectorNameLowerCase}.config.hostUrl.help")
+    @ConfigurationProperty(displayMessageKey = "gitlab.config.hostUrl",
+            helpMessageKey = "gitlab.config.hostUrl.help")
     public String getHostUrl() {
         return hostUrl;
     }
@@ -41,9 +39,9 @@ public class GitlabConfiguration extends AbstractConfiguration {
     public void setHostUrl(String hostUrl) {
         this.hostUrl = hostUrl;
     }
-    
-    @ConfigurationProperty(displayMessageKey = "${connectorNameLowerCase}.config.apiToken",
-            helpMessageKey = "${connectorNameLowerCase}.config.apiToken.help")
+
+    @ConfigurationProperty(displayMessageKey = "gitlab.config.apiToken",
+            helpMessageKey = "gitlab.config.apiToken.help")
     public String getApiToken() {
         return apiToken;
     }
@@ -52,4 +50,13 @@ public class GitlabConfiguration extends AbstractConfiguration {
         this.apiToken = apiToken;
     }
 
+    @ConfigurationProperty(displayMessageKey = "gitlab.config.ignoreCertificateErrors",
+            helpMessageKey = "gitlab.config.ignoreCertificateErrors.help")
+    public boolean getIgnoreCertificateErrors() {
+        return ignoreCertificateErrors;
+    }
+
+    public void setIgnoreCertificateErrors(boolean ignoreCertificateErrors) {
+        this.ignoreCertificateErrors = ignoreCertificateErrors;
+    }
 }

--- a/src/main/java/com/evolveum/polygon/connector/gitlab/GitlabConnector.java
+++ b/src/main/java/com/evolveum/polygon/connector/gitlab/GitlabConnector.java
@@ -32,7 +32,6 @@ import org.identityconnectors.common.logging.Log;
 import org.identityconnectors.common.security.GuardedString;
 import org.identityconnectors.framework.common.objects.Attribute;
 import org.identityconnectors.framework.common.objects.AttributeBuilder;
-import org.identityconnectors.framework.common.objects.AttributeInfo;
 import org.identityconnectors.framework.common.objects.AttributeInfoBuilder;
 import org.identityconnectors.framework.common.objects.ConnectorObject;
 import org.identityconnectors.framework.common.objects.ConnectorObjectBuilder;
@@ -78,7 +77,7 @@ public class GitlabConnector implements Connector, CreateOp, DeleteOp, SchemaOp,
 	private static final String ATTR_BIO = "bio";
 	private static final String ATTR_IS_ADMIN = "isAdmin";
 	private static final String ATTR_CAN_CREATE_GROUP = "canCreateGroup";
-	private static final String ATTR_SKIP_CONFIRMATION = "skipConfirmation";
+	private static final String ATTR_CONFIRM = "confirm";
 	private static final String ATTR_PATH = "path";
 	private static final String ATTR_MEMBER = "member";
 	private static final String ATTR_DEFAULT_BRANCH = "defaultBranch";
@@ -143,7 +142,7 @@ public class GitlabConnector implements Connector, CreateOp, DeleteOp, SchemaOp,
 		objClassBuilder.addAttributeInfo(new AttributeInfoBuilder(ATTR_BIO).build());
 		objClassBuilder.addAttributeInfo(new AttributeInfoBuilder(ATTR_IS_ADMIN, Boolean.class).build());
 		objClassBuilder.addAttributeInfo(new AttributeInfoBuilder(ATTR_CAN_CREATE_GROUP, Boolean.class).build());
-		objClassBuilder.addAttributeInfo(new AttributeInfoBuilder(ATTR_SKIP_CONFIRMATION, Boolean.class).build());
+		objClassBuilder.addAttributeInfo(new AttributeInfoBuilder(ATTR_CONFIRM, Boolean.class).build());
 		// __PASSWORD__ attribute
         objClassBuilder.addAttributeInfo(OperationalAttributeInfos.PASSWORD);
 		
@@ -261,12 +260,8 @@ public class GitlabConnector implements Connector, CreateOp, DeleteOp, SchemaOp,
 		String bio = getStringAttr(attributes, ATTR_BIO, origUser.getBio());
 		Boolean isAdmin = getAttr(attributes, ATTR_IS_ADMIN, Boolean.class, origUser.isAdmin());
 		Boolean can_create_group = getAttr(attributes, ATTR_CAN_CREATE_GROUP, Boolean.class, origUser.isCanCreateGroup());
-		Boolean skip_confirmation = getAttr(attributes, ATTR_SKIP_CONFIRMATION, Boolean.class);
-		if (skip_confirmation == null) {
-			skip_confirmation = Boolean.TRUE;
-		}
 		try {
-			GitlabUser gitlabUser = gitlabAPI.updateUser(targetUserId, email, password, username, fullName, skypeId, linkedIn, twitter, website_url, projects_limit, extern_uid, extern_provider_name, bio, isAdmin, can_create_group, skip_confirmation);
+			GitlabUser gitlabUser = gitlabAPI.updateUser(targetUserId, email, password, username, fullName, skypeId, linkedIn, twitter, website_url, projects_limit, extern_uid, extern_provider_name, bio, isAdmin, can_create_group);
 		} catch (IOException e) {
 			throw new ConnectorIOException(e.getMessage(), e);
 		}
@@ -614,7 +609,7 @@ public class GitlabConnector implements Connector, CreateOp, DeleteOp, SchemaOp,
 		String bio = getStringAttr(attributes, ATTR_BIO);
 		Boolean isAdmin = getAttr(attributes, ATTR_IS_ADMIN, Boolean.class);
 		Boolean can_create_group = getAttr(attributes, ATTR_CAN_CREATE_GROUP, Boolean.class);;
-		Boolean skip_confirmation = getAttr(attributes, ATTR_SKIP_CONFIRMATION, Boolean.class);
+		Boolean skip_confirmation = getAttr(attributes, ATTR_CONFIRM, Boolean.class);
 		if (skip_confirmation == null) {
 			skip_confirmation = Boolean.TRUE;
 		}

--- a/src/main/java/com/evolveum/polygon/connector/gitlab/GitlabConnector.java
+++ b/src/main/java/com/evolveum/polygon/connector/gitlab/GitlabConnector.java
@@ -110,6 +110,7 @@ public class GitlabConnector implements Connector, CreateOp, DeleteOp, SchemaOp,
         this.configuration = (GitlabConfiguration)configuration;
         gitlabAPI = GitlabAPI.connect(this.configuration.getHostUrl(),
         		this.configuration.getApiToken());
+        gitlabAPI.ignoreCertificateErrors(this.configuration.getIgnoreCertificateErrors());
     }
     
 	@Override
@@ -264,7 +265,6 @@ public class GitlabConnector implements Connector, CreateOp, DeleteOp, SchemaOp,
 		if (skip_confirmation == null) {
 			skip_confirmation = Boolean.TRUE;
 		}
-
 		try {
 			GitlabUser gitlabUser = gitlabAPI.updateUser(targetUserId, email, password, username, fullName, skypeId, linkedIn, twitter, website_url, projects_limit, extern_uid, extern_provider_name, bio, isAdmin, can_create_group, skip_confirmation);
 		} catch (IOException e) {

--- a/src/main/resources/com/evolveum/polygon/Message.properties
+++ b/src/main/resources/com/evolveum/polygon/Message.properties
@@ -15,5 +15,9 @@
 #
 
 gitlab.connector.display=gitlab
-gitlab.config.sampleProperty=Sample property display name
-gitlab.config.sampleProperty.help=Sample property description
+gitlab.config.apiToken=Private Token
+gitlab.config.apiToken.help=Private token is used to access the GitLab API and Atom feeds.
+gitlab.config.hostUrl=Sample property display name
+gitlab.config.hostUrl.help=Sample property description
+gitlab.config.ignoreCertificateErrors=Ignore SSL Certificate Errors
+gitlab.config.sslVerify.help=Trust Self-Signed SSL certificates and ignore SSL Errors.


### PR DESCRIPTION
- Added ignore SSL certificate errors to support self-signed certs
- Upgraded java-gitlab-api dependency to v1.2.7